### PR TITLE
Moved routes so Rails picks it up automatically

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,20 @@
+Openapi::Engine.routes.draw do
+  Openapi.apis.each do |name, config|
+    base_path = config[:base_path] || '/api'
+
+    config[:controllers].each do |controller|
+      if controller.respond_to?(:build_openapi_specification)
+        controller.build_openapi_specification(base_path: base_path)
+      else
+        raise NoMethodError, 'Restart the Rails server after changing a resource in the api routes.'
+      end
+    end
+
+    name = name.to_s.titleize.remove(' ')
+    root_klass_name = "#{name}SwaggerRootController"
+    klass = Object.const_set root_klass_name, Class.new(Openapi::SwaggerRoot)
+    klass.build_specification(config, config[:controllers])
+
+    config[:controllers].push klass
+  end
+end

--- a/lib/openapi/engine.rb
+++ b/lib/openapi/engine.rb
@@ -8,25 +8,4 @@ module Openapi
                                          openapi/favicon-16x16.png)
     end
   end
-
-  class Railtie < Rails::Railtie
-    initializer 'openapi.builders', after: :load_config_initializers do
-      Rails.application.reload_routes!
-
-      Openapi.apis.each do |name, config|
-        base_path = config[:base_path] || '/api'
-
-        config[:controllers].each do |controller|
-          controller.build_openapi_specification(base_path: base_path)
-        end
-
-        name = name.to_s.titleize.remove(' ')
-        root_klass_name = "#{name}SwaggerRootController"
-        klass = Object.const_set root_klass_name, Class.new(SwaggerRoot)
-        klass.build_specification(config, config[:controllers])
-
-        config[:controllers].push klass
-      end
-    end
-  end
 end


### PR DESCRIPTION
By moving the code to create the routes it is automatically picked up by the host app. For us this seems to be the only way to make it play nice with other gems that also add routes.

I tried a bunch of different ways to make this work including using different points in the initialization process of the Rails app. None of them worked.

The disadvantage to this method is that changes to the api routes of main app do not get picked up without restarting the server. I therefore included a raise which tells the user the server needs to restarted.
